### PR TITLE
ci: run integration tests on same-repo PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
     name: Integration Tests (Chat / Anthropic)
     needs: check
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Updates the integration job condition to also run on pull_request events when the PR originates from the same repository (not a fork). This ensures integration tests run during PR review while still protecting secrets from fork PRs.