### PR TITLE
feat: connective nodes (anyof/allof)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,9 @@ jobs:
       - name: Run integration tests
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Must be a currently served model ID — retired IDs 404. Bump here
+          # without a code change; the test defaults to this same value.
+          ANTHROPIC_MODEL: claude-sonnet-5
         run: yarn vitest run packages/ui/__tests__/chat/integration.test.ts
 
   vscode:

--- a/docs/VINE/proposals/connective-nodes.md
+++ b/docs/VINE/proposals/connective-nodes.md
@@ -1,0 +1,239 @@
+# Proposal: First-Class Connective Nodes
+
+**Status:** Implemented in `@bacchus/core` (VINE 1.3.0), surfaced through the MCP `vine_write` `add_connective` op. Not yet in the UI renderer or a formal `docs/VINE/v1.3.0.md` spec.
+**Targets issue:** [#22 — VINE: distinguish 'blocked (needs intervention)' from 'deferred (waiting on external trigger)'](https://github.com/goldenwitch/bacchus/issues/22)
+**VINE version:** 1.3.0 (grammar change — see [Versioning & Compatibility](#versioning--compatibility))
+**Precedent:** the existing `ref` structural node ([v1.2.0 spec](../v1.2.0.md#reference-block))
+
+---
+
+## Boundary
+
+The VINE core owns **graph connectivity and routing**. It does not assign execution semantics to header annotations. New core constructs that affect **traversal or readiness** are explicit **node kinds**, not annotation keys.
+
+`ref` is the existing structural-node precedent: a first-class block form (`ref [id] Name (URI)`) that participates in the dependency graph — other nodes depend on it, it declares its own dependencies, validation and expansion see it — while carrying no task lifecycle of its own. `anyof` and `allof` extend that same design space. They add routing vocabulary without adding domain-specific task semantics.
+
+This is a deliberate rejection of the `@anyof(...)` **annotation** path floated in the [#22 discussion](https://github.com/goldenwitch/bacchus/issues/22#issuecomment-4953911965). See [Why a node kind, not an annotation](#why-a-node-kind-not-an-annotation).
+
+---
+
+## Connective Nodes
+
+Two new block kinds join `task` and `ref`:
+
+```vine
+[gap-memory] Belief beyond the window (notstarted)
+-> memory-trigger
+---
+anyof [memory-trigger] First relevant regime signal
+-> r4-scoping
+-> spirit-2-intake
+```
+
+- **`anyof`** is *satisfied* when **any** direct dependency is satisfied.
+- **`allof`** is *satisfied* when **every** direct dependency is satisfied.
+- Connective nodes have **no writable status**, **cannot be claimed or completed**, and **never enter `ready_to_start`** (nor any other frontier bucket).
+- A dependant treats a satisfied connective node as a **satisfied prerequisite**, using the existing dependency-satisfaction rule — the connective is transparent to the dependant.
+
+An `allof` node is useful even though ordinary task dependencies are already conjunctive: it **names and reuses** a derived readiness condition without inventing a task owner or a manual lifecycle. Where `anyof` adds an expressiveness the format cannot otherwise state (disjunction), `allof` adds *reuse and naming* of the conjunction the format already has.
+
+### Header form
+
+| Header form                | Block kind      | Status field | Attachments |
+| -------------------------- | --------------- | ------------ | ----------- |
+| `[id] Name (status)`       | task            | required     | allowed     |
+| `ref [id] Name (URI)`      | reference       | —            | forbidden   |
+| `anyof [id] Name`          | connective (∨)  | —            | forbidden   |
+| `allof [id] Name`          | connective (∧)  | —            | forbidden   |
+
+A connective header is the keyword (`anyof` / `allof`), an `[id]`, a short name, and optional [header annotations](../v1.2.0.md#header-annotations). Unlike task and ref headers it has **no trailing parenthesized field** — there is no status to set and no URI to resolve.
+
+**Connective header regexes** (mirroring the task/ref forms):
+
+```
+^anyof\s+\[([a-zA-Z0-9-]+(?:/[a-zA-Z0-9-]+)*)\]\s+(.+?)((?:\s+@[a-zA-Z][a-zA-Z0-9]*\([^)]*\))*)$
+^allof\s+\[([a-zA-Z0-9-]+(?:/[a-zA-Z0-9-]+)*)\]\s+(.+?)((?:\s+@[a-zA-Z][a-zA-Z0-9]*\([^)]*\))*)$
+```
+
+### Body lines
+
+Connective body lines use the same prefix-priority dispatch as `ref`, minus attachments:
+
+| Allowed | Prefix   | Meaning        |
+| ------- | -------- | -------------- |
+| **Yes** | `-> `    | Dependency     |
+| **Yes** | `> `     | Decision       |
+| **Yes** | *(none)* | Description    |
+| **No**  | `@*`     | Attachment (forbidden, as on `ref`) |
+
+Dependencies are the point of a connective — they are the inputs to its satisfaction rule. Description text serves as the human-facing statement of the routing condition ("first relevant regime signal"). Decisions may record why the disjunction/conjunction is drawn this way.
+
+### Satisfaction predicate
+
+The frontier already computes, for every dependency edge, whether the target is *satisfied*. Connectives reuse that predicate and extend it recursively:
+
+```
+satisfied(n):
+  task  → n.status ∈ { complete, reviewing }      # the existing rule
+  ref   → (existing per-node rule / expanded status)
+  anyof → ∃ d ∈ deps(n):  satisfied(d)
+  allof → ∀ d ∈ deps(n):  satisfied(d)
+```
+
+A task/ref dependant is ready exactly as before — "all dependencies satisfied" — except `satisfied()` now resolves connectives transparently. No new readiness rule is introduced at the dependant; the recursion lives entirely inside the predicate. Termination is guaranteed by the DAG constraint.
+
+### Parsing dispatch
+
+Header classification is decided on the **first token**, extending the v1.2.0 algorithm ([step 5](../v1.2.0.md#parsing-algorithm)):
+
+```
+first token == "ref"    → reference block
+first token == "anyof"  → anyof connective block
+first token == "allof"  → allof connective block
+otherwise               → task block   (must start with "[")
+```
+
+---
+
+## Grammar
+
+Additions to the [v1.2.0 ABNF](../v1.2.0.md#abnf-grammar):
+
+```abnf
+node-block     = task-block / ref-block / anyof-block / allof-block
+
+; ── Connective blocks ──
+
+anyof-block    = anyof-header LF *conn-body-line
+anyof-header   = %s"anyof" 1*WSP "[" task-id "]" 1*WSP short-name *annotation
+
+allof-block    = allof-header LF *conn-body-line
+allof-header   = %s"allof" 1*WSP "[" task-id "]" 1*WSP short-name *annotation
+
+conn-body-line = dependency / decision / description-line
+                                                ; no status, no attachments
+```
+
+`task-id`, `short-name`, `dependency`, `decision`, `description-line`, and `annotation` are unchanged from v1.2.0. Connectives share the single ID namespace with tasks and refs.
+
+---
+
+## Validation
+
+Connective nodes are ordinary graph citizens for every existing structural constraint, plus one addition:
+
+1. **Unique IDs** — connective IDs share the namespace; no collisions with task/ref IDs.
+2. **Valid dependency refs** — every `-> <id>` on a connective must resolve to a node in the same file. Every `-> <connective-id>` from a task/ref must likewise resolve.
+3. **No cycles** — connectives participate in cycle detection like any node.
+4. **No islands** — connectives must be reachable from the root by dependency edges.
+5. **Non-empty connective** *(new)* — an `anyof`/`allof` node **must declare at least one dependency**. A zero-dependency `anyof` can never be satisfied (a silent permanent block); a zero-dependency `allof` is vacuously satisfied (a silent no-op). Both are almost certainly authoring errors, so the parser rejects them rather than guessing intent.
+6. **No status / no attachments on connectives** — enforced syntactically by the header grammar and body-line rules.
+7. **Root is not a connective** *(new)* — the root (first block) represents the graph's goal and carries a status; a connective has neither, so it may not be the root. The root must be a task or a ref.
+
+---
+
+## Frontier behavior (`vine_next`)
+
+Connective nodes are **pure routing** and never appear in any [`vine_next`](../MCP.md#vine_next) bucket — not `ready_to_start`, `ready_to_complete`, `needs_expansion`, or `blocked`. They are not work; there is nothing to pick up, review, or expand.
+
+Their only effect on the frontier is through the satisfaction predicate: a task that depends on a connective becomes ready the moment the connective is satisfied — i.e., the moment its underlying disjunction/conjunction fires. No polling agent, no manual "trigger node" completion.
+
+`progress` counts (`total`, `complete`, `percentage`, `by_status`, `ready_count`) **exclude connectives** — they are routing infrastructure, not deliverable work, and including them would distort completion metrics.
+
+---
+
+## Expansion
+
+Connectives behave like tasks under [expansion](../v1.2.0.md#expansion):
+
+- On inlining a child graph, connective IDs are prefixed with the child prefix exactly like task IDs (`memory-trigger` → `child/memory-trigger`), and their `-> ` targets are remapped correspondingly.
+- Annotations on connectives are preserved on the remapped node, consistent with the v1.2.0 rule.
+- Because the [root is never a connective](#validation), a connective can never occupy the reference node's slot, so the "child root adopts the ref node's ID and status" step is unaffected.
+
+---
+
+## Serialization
+
+Canonical body-line order for a connective block (mirrors `ref`, minus attachments):
+
+1. Description lines (internal newlines preserved)
+2. Dependencies (`-> ...`), sorted alphabetically by target id
+3. Decisions (`> ...`), in original order
+
+Header annotations are appended after the short name in alphabetical key order, matching task/ref serialization.
+
+---
+
+## Worked example — the #22 deferral, resolved
+
+The [#22](https://github.com/goldenwitch/bacchus/issues/22) case: a "sized capability gap" that must **not** appear in the ready-to-start frontier until an external trigger fires — where the trigger is a disjunction ("second spirit intake **or** r4 stable-noise scoping, whichever lands first"). Ordinary conjunctive `->` cannot state the OR; the prior workaround overloaded `blocked`.
+
+```vine
+vine 1.3.0
+title: Long-horizon research graph
+---
+[root] Dog build graph (started)
+-> gap-memory
+---
+[gap-memory] Belief beyond the 7-frame window (notstarted)
+The sized capability gap. Binds when the first relevant regime signal lands.
+-> memory-trigger
+---
+anyof [memory-trigger] First relevant regime signal
+Fires on whichever upstream lands first — no intervention, not alarming.
+-> r4-scoping
+-> spirit-2-intake
+---
+[r4-scoping] r4 stable-noise scoping (notstarted)
+---
+[spirit-2-intake] Second spirit intake (notstarted)
+```
+
+While both `r4-scoping` and `spirit-2-intake` are incomplete, `memory-trigger` is unsatisfied, so `gap-memory` is **not** in `ready_to_start` — and nothing is reported as `blocked`, because nothing needs intervention. The instant either upstream reaches `complete`/`reviewing`, `memory-trigger` becomes satisfied and `gap-memory` enters the frontier. The deferral is truthful, the `blocked` status keeps its "needs intervention" meaning, and no judgment/polling task exists to babysit.
+
+---
+
+## Consequences
+
+- Every routing relationship remains an ordinary `-> ` edge — **visible to validation, traversal, expansion, and graph rendering**. Nothing about readiness hides inside annotation text a renderer would ignore.
+- A connective can be **named, documented, and shared** by multiple dependants. "First relevant regime signal" is stated once and reused, rather than re-encoded per node.
+- `@anyof` is **not** a core feature; annotations remain non-routing metadata. The design principle from [#13](https://github.com/goldenwitch/bacchus/issues/13) — routing lives in graph structure, annotations decorate — is preserved structurally, not by governance.
+- Issue [#22](https://github.com/goldenwitch/bacchus/issues/22) is met by `anyof` **without a polling judgment task** and without overloading `blocked`.
+
+### Why a node kind, not an annotation
+
+The [#22 comment thread](https://github.com/goldenwitch/bacchus/issues/22#issuecomment-4953911965) proposed `@anyof(r4,spirit-2)` as a header annotation — attractive because unknown annotations are forward-compatible under v1.2.0, so no version bump is needed. This proposal rejects that path on principle:
+
+| | `@anyof(...)` annotation | `anyof` node kind (this proposal) |
+| --- | --- | --- |
+| Routing visible to graph tools | No — buried in annotation text; renderers/validators ignore unknown keys | Yes — ordinary `-> ` edges |
+| Reusable across dependants | No — repeated per node | Yes — one named node, many dependants |
+| Overloads annotation semantics | Yes — makes an annotation affect readiness | No — annotations stay non-routing |
+| Forward-compatible with v1.2.0 parsers | Yes (silently ignored) | No — requires 1.3.0 (see below) |
+| Validation of targets / cycles / islands | Requires special-casing an annotation | Free — it's a node |
+
+The forward-compatibility of the annotation path is a *liability* here, not a feature: a v1.2.0 tool would silently ignore `@anyof`, computing readiness as if the disjunction did not exist. A first-class node makes older tools **fail loudly** (unknown block kind) rather than **route wrongly in silence**.
+
+---
+
+## Versioning & Compatibility
+
+This is a **grammar change**, so it requires a minor version bump to **VINE 1.3.0** and cannot be forward-compatible the way annotations are:
+
+- A 1.3.0 parser must still accept 1.0.0 / 1.1.0 / 1.2.0 files unchanged (connectives are purely additive).
+- A **1.2.0 parser encountering a 1.3.0 file with `anyof`/`allof` headers will reject them** — the headers match neither the task nor the ref regex ("invalid header"). This is correct and intended: version dispatch on the magic line means a 1.2.0 tool refuses a 1.3.0 file outright rather than misinterpreting its routing.
+
+Implementation would follow the [VINE Version Upgrade Guide](../VINE-VERSIONING.md): new `NodeKind`/block types in `@bacchus/core` types, parser dispatch + header regexes, serializer body-order for connectives, validator constraints (non-empty connective, root-not-connective, satisfaction recursion), frontier exclusion in `getActionableTasks`, and UI/CLI/MCP surfacing.
+
+---
+
+## Open Decisions
+
+1. **May connective nodes depend on other connective nodes?**
+   *Recommendation: yes.* It composes cleanly (`allof` over several `anyof`s, etc.), the satisfaction predicate already recurses, and the DAG constraint guarantees termination. Disallowing it would be a special-case carve-out with no clear benefit.
+
+2. **How does review handoff treat an upstream node that satisfies a connective?**
+   `ready_to_complete` currently means "a `reviewing` task whose dependant has **started consuming** its output." With a connective interposed, the question is whether the connective is transparent to that check. *Recommendation: transparent* — the effective consumers of an upstream `U` are the task/ref dependants reachable **through** connective nodes, so a `reviewing` `U` is `ready_to_complete` when any such transitive consumer has started. This keeps the handoff semantics identical to the direct-edge case.
+
+3. **Which derived connective state is exposed by inspection and visualization tools?**
+   Candidates: `task`/`context` responses report `kind: "anyof" | "allof"`, a computed `satisfied: boolean`, and optionally `satisfiedBy` (which dependency/dependencies currently satisfy it); `vine_next.progress` excludes connectives from totals; visualization renders connectives as a distinct routing glyph (e.g. an ∨/∧ gate or diamond) showing satisfied vs. unsatisfied state rather than a task-status color. *Recommendation: expose `kind` + `satisfied` at minimum; treat richer detail (`satisfiedBy`) and the visual glyph as follow-ups.*

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -11,7 +11,9 @@ import {
 import type { Task } from '@bacchus/core';
 
 function statusLabel(task: Task): string {
-  return task.kind === 'task' ? task.status : 'ref';
+  // Concrete tasks show their status; structural nodes show their kind
+  // (`ref`, `anyof`, `allof`).
+  return task.kind === 'task' ? task.status : task.kind;
 }
 
 function printTaskTable(tasks: Task[]): void {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -28,8 +28,8 @@ export const statusCommand = new Command('status')
     try {
       let graph = readGraph(file);
       const task = getTask(graph, id);
-      if (task.kind === 'ref') {
-        console.error(`Task "${id}" is a ref node and has no status.`);
+      if (task.kind !== 'task') {
+        console.error(`Task "${id}" is a ${task.kind} node and has no status.`);
         process.exitCode = 1;
         return;
       }

--- a/packages/core/__tests__/connectives.test.ts
+++ b/packages/core/__tests__/connectives.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from 'vitest';
+import { parse } from '../src/parser.js';
+import { serialize } from '../src/serializer.js';
+import { setStatus, applyBatch } from '../src/mutations.js';
+import { getActionableTasks, buildSatisfaction } from '../src/search.js';
+import { isConnective } from '../src/types.js';
+import type { ConnectiveNode } from '../src/types.js';
+import { VineParseError, VineValidationError } from '../src/errors.js';
+
+// ---------------------------------------------------------------------------
+// The canonical #22 deferral graph:
+//
+//   gap-memory becomes actionable when the FIRST of two external triggers
+//   lands (disjunction), expressed with an `anyof` connective — no polling
+//   judgment task, and `blocked` keeps its "needs intervention" meaning.
+// ---------------------------------------------------------------------------
+const DEFERRAL = [
+  'vine 1.3.0',
+  'title: Long-horizon research graph',
+  '---',
+  '[root] Dog build graph (started)',
+  '-> gap-memory',
+  '---',
+  '[gap-memory] Belief beyond the 7-frame window (notstarted)',
+  'The sized capability gap.',
+  '-> memory-trigger',
+  '---',
+  'anyof [memory-trigger] First relevant regime signal',
+  'Fires on whichever upstream lands first.',
+  '-> r4-scoping',
+  '-> spirit-2-intake',
+  '---',
+  '[r4-scoping] r4 stable-noise scoping (notstarted)',
+  '---',
+  '[spirit-2-intake] Second spirit intake (notstarted)',
+].join('\n');
+
+describe('parsing connective nodes', () => {
+  it('parses an anyof node with dependencies and description', () => {
+    const graph = parse(DEFERRAL);
+    const trigger = graph.tasks.get('memory-trigger');
+    expect(trigger).toBeDefined();
+    expect(trigger?.kind).toBe('anyof');
+    expect(isConnective(trigger!)).toBe(true);
+    expect(trigger?.dependencies).toEqual(['r4-scoping', 'spirit-2-intake']);
+    expect(trigger?.description).toBe('Fires on whichever upstream lands first.');
+    // Connectives carry no status field.
+    expect('status' in (trigger as object)).toBe(false);
+  });
+
+  it('parses an allof node', () => {
+    const graph = parse(
+      [
+        'vine 1.3.0',
+        '---',
+        '[root] Root (started)',
+        '-> gate',
+        '---',
+        'allof [gate] Everything ready',
+        '-> a',
+        '-> b',
+        '---',
+        '[a] A (complete)',
+        '---',
+        '[b] B (complete)',
+      ].join('\n'),
+    );
+    expect(graph.tasks.get('gate')?.kind).toBe('allof');
+  });
+
+  it('rejects attachments on a connective node', () => {
+    const text = [
+      'vine 1.3.0',
+      '---',
+      '[root] Root (started)',
+      '-> c',
+      '---',
+      'anyof [c] Signal',
+      '-> a',
+      '@file text/plain https://example.com/x.txt',
+      '---',
+      '[a] A (complete)',
+    ].join('\n');
+    expect(() => parse(text)).toThrow(VineParseError);
+    expect(() => parse(text)).toThrow(/Attachments are not allowed on connective/);
+  });
+});
+
+describe('serializing connective nodes', () => {
+  it('round-trips a graph containing connectives', () => {
+    const graph = parse(DEFERRAL);
+    const reparsed = parse(serialize(graph));
+    expect(serialize(reparsed)).toBe(serialize(graph));
+  });
+
+  it('emits the `anyof`/`allof` keyword header with no status paren', () => {
+    const out = serialize(parse(DEFERRAL));
+    expect(out).toContain('anyof [memory-trigger] First relevant regime signal');
+    expect(out).not.toMatch(/memory-trigger.*\(/);
+  });
+});
+
+describe('validating connective nodes', () => {
+  it('rejects a connective with zero dependencies', () => {
+    const text = [
+      'vine 1.3.0',
+      '---',
+      '[root] Root (started)',
+      '-> c',
+      '---',
+      'anyof [c] Empty connective',
+    ].join('\n');
+    try {
+      parse(text);
+      expect.fail('expected validation to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(VineValidationError);
+      expect((err as VineValidationError).constraint).toBe('connective-has-deps');
+    }
+  });
+
+  it('rejects a connective as the root node', () => {
+    const text = [
+      'vine 1.3.0',
+      '---',
+      'anyof [root] Root connective',
+      '-> a',
+      '---',
+      '[a] A (complete)',
+    ].join('\n');
+    try {
+      parse(text);
+      expect.fail('expected validation to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(VineValidationError);
+      expect((err as VineValidationError).constraint).toBe('root-not-connective');
+    }
+  });
+});
+
+describe('buildSatisfaction', () => {
+  it('anyof is satisfied when any dependency is satisfied', () => {
+    const graph = setStatus(parse(DEFERRAL), 'r4-scoping', 'complete');
+    const satisfied = buildSatisfaction(graph);
+    expect(satisfied('memory-trigger')).toBe(true);
+  });
+
+  it('anyof is unsatisfied while all dependencies are unsatisfied', () => {
+    const satisfied = buildSatisfaction(parse(DEFERRAL));
+    expect(satisfied('memory-trigger')).toBe(false);
+  });
+
+  it('allof requires every dependency to be satisfied', () => {
+    const base = [
+      'vine 1.3.0',
+      '---',
+      '[root] Root (started)',
+      '-> gate',
+      '---',
+      'allof [gate] All inputs',
+      '-> a',
+      '-> b',
+      '---',
+      '[a] A (notstarted)',
+      '---',
+      '[b] B (notstarted)',
+    ].join('\n');
+    const oneDone = setStatus(parse(base), 'a', 'complete');
+    expect(buildSatisfaction(oneDone)('gate')).toBe(false);
+    const bothDone = setStatus(oneDone, 'b', 'complete');
+    expect(buildSatisfaction(bothDone)('gate')).toBe(true);
+  });
+});
+
+describe('execution frontier with connectives', () => {
+  it('keeps a connective-gated node out of the frontier until the anyof fires', () => {
+    const graph = parse(DEFERRAL);
+    const frontier = getActionableTasks(graph);
+
+    // The two leaf triggers are ready; the gated node is NOT; nothing blocked.
+    expect(frontier.ready.map((t) => t.id).sort()).toEqual([
+      'r4-scoping',
+      'spirit-2-intake',
+    ]);
+    expect(frontier.ready.map((t) => t.id)).not.toContain('gap-memory');
+    expect(frontier.blocked).toHaveLength(0);
+  });
+
+  it('promotes the gated node once one upstream completes', () => {
+    const graph = setStatus(parse(DEFERRAL), 'r4-scoping', 'complete');
+    const frontier = getActionableTasks(graph);
+    expect(frontier.ready.map((t) => t.id)).toContain('gap-memory');
+  });
+
+  it('never lists a connective in any frontier bucket', () => {
+    const graph = setStatus(parse(DEFERRAL), 'r4-scoping', 'complete');
+    const frontier = getActionableTasks(graph);
+    const all = [
+      ...frontier.ready,
+      ...frontier.completable,
+      ...frontier.blocked,
+      ...frontier.expandable,
+    ].map((t) => t.id);
+    expect(all).not.toContain('memory-trigger');
+  });
+
+  it('excludes connectives from the progress denominator', () => {
+    const graph = parse(DEFERRAL);
+    const { progress } = getActionableTasks(graph);
+    // 5 nodes total, but memory-trigger (connective) is not work.
+    expect(graph.tasks.size).toBe(5);
+    expect(progress.total).toBe(4);
+  });
+});
+
+describe('mutations on connective nodes', () => {
+  it('creates a connective via the add_connective batch op', () => {
+    const base = parse(
+      [
+        'vine 1.3.0',
+        '---',
+        '[root] Root (started)',
+        '-> a',
+        '-> b',
+        '---',
+        '[a] A (complete)',
+        '---',
+        '[b] B (complete)',
+      ].join('\n'),
+    );
+    const next = applyBatch(base, [
+      { op: 'add_connective', id: 'gate', name: 'Any input', kind: 'anyof', dependsOn: ['a', 'b'] },
+      { op: 'add_dep', taskId: 'root', depId: 'gate' },
+    ]);
+    const gate = next.tasks.get('gate') as ConnectiveNode;
+    expect(gate.kind).toBe('anyof');
+    expect(gate.dependencies).toEqual(['a', 'b']);
+  });
+
+  it('refuses to set a status on a connective', () => {
+    const graph = parse(DEFERRAL);
+    expect(() => setStatus(graph, 'memory-trigger', 'complete')).toThrow(
+      /Cannot set status on anyof node/,
+    );
+  });
+});

--- a/packages/core/__tests__/connectives.test.ts
+++ b/packages/core/__tests__/connectives.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect } from 'vitest';
 import { parse } from '../src/parser.js';
 import { serialize } from '../src/serializer.js';
 import { setStatus, applyBatch } from '../src/mutations.js';
-import { getActionableTasks, buildSatisfaction } from '../src/search.js';
+import {
+  getActionableTasks,
+  buildSatisfaction,
+  getSummary,
+} from '../src/search.js';
 import { isConnective } from '../src/types.js';
 import type { ConnectiveNode } from '../src/types.js';
 import { VineParseError, VineValidationError } from '../src/errors.js';
@@ -210,6 +214,15 @@ describe('execution frontier with connectives', () => {
     // 5 nodes total, but memory-trigger (connective) is not work.
     expect(graph.tasks.size).toBe(5);
     expect(progress.total).toBe(4);
+  });
+
+  it('getSummary.total excludes connectives, matching vine_next', () => {
+    const graph = parse(DEFERRAL);
+    const summary = getSummary(graph);
+    const { progress } = getActionableTasks(graph);
+    // Both surfaces must agree — connectives are not deliverable work.
+    expect(summary.total).toBe(4);
+    expect(summary.total).toBe(progress.total);
   });
 });
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -29,7 +29,9 @@ export type ValidationConstraint =
   | 'no-cycles'
   | 'no-islands'
   | 'ref-uri-required'
-  | 'no-ref-attachments';
+  | 'no-ref-attachments'
+  | 'connective-has-deps'
+  | 'root-not-connective';
 
 /**
  * Discriminated union carrying details about which constraint was violated.
@@ -40,7 +42,9 @@ export type ValidationDetails =
   | { constraint: 'no-cycles'; cycle: string[] }
   | { constraint: 'no-islands'; islandTaskIds: string[] }
   | { constraint: 'ref-uri-required'; taskId: string }
-  | { constraint: 'no-ref-attachments'; taskId: string };
+  | { constraint: 'no-ref-attachments'; taskId: string }
+  | { constraint: 'connective-has-deps'; taskId: string }
+  | { constraint: 'root-not-connective'; taskId: string };
 
 /**
  * Thrown when a structural constraint is violated.

--- a/packages/core/src/expansion.ts
+++ b/packages/core/src/expansion.ts
@@ -1,4 +1,10 @@
-import type { ConcreteTask, RefTask, Task, VineGraph } from './types.js';
+import type {
+  ConcreteTask,
+  ConnectiveNode,
+  RefTask,
+  Task,
+  VineGraph,
+} from './types.js';
 import { VineError } from './errors.js';
 import { validate } from './validator.js';
 
@@ -136,7 +142,7 @@ export function expandVineRef(
         vine: childTask.vine,
         annotations: childTask.annotations,
       } satisfies RefTask);
-    } else {
+    } else if (childTask.kind === 'task') {
       remappedChildTasks.push({
         kind: 'task',
         id: remappedId,
@@ -148,6 +154,17 @@ export function expandVineRef(
         attachments: childTask.attachments,
         annotations: childTask.annotations,
       } satisfies ConcreteTask);
+    } else {
+      // Connective node (anyof / allof).
+      remappedChildTasks.push({
+        kind: childTask.kind,
+        id: remappedId,
+        shortName: childTask.shortName,
+        description: childTask.description,
+        dependencies: remappedDeps,
+        decisions: childTask.decisions,
+        annotations: childTask.annotations,
+      } satisfies ConnectiveNode);
     }
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,8 @@ export type {
   Attachment,
   AttachmentClass,
   ConcreteTask,
+  ConnectiveKind,
+  ConnectiveNode,
   Operation,
   RefTask,
   Status,
@@ -15,6 +17,7 @@ export {
   isValidStatus,
   isVineRef,
   isConcreteTask,
+  isConnective,
   getSpriteUri,
 } from './types.js';
 
@@ -39,6 +42,7 @@ export {
 // Mutations
 export {
   addRef,
+  addConnective,
   addTask,
   applyBatch,
   removeTask,
@@ -61,6 +65,7 @@ export type {
 export {
   filterByStatus,
   getActionableTasks,
+  buildSatisfaction,
   searchTasks,
   getLeaves,
   getRefs,

--- a/packages/core/src/mutations.ts
+++ b/packages/core/src/mutations.ts
@@ -1,5 +1,6 @@
 import type {
   ConcreteTask,
+  ConnectiveNode,
   Operation,
   RefTask,
   Status,
@@ -30,6 +31,14 @@ function buildGraph(
     tasks,
     order,
   };
+}
+
+/**
+ * Human-readable label for a node kind, used in error messages.
+ * `ref` reads as "reference"; connectives read as their keyword.
+ */
+function nodeKindLabel(kind: Task['kind']): string {
+  return kind === 'ref' ? 'reference' : kind;
 }
 
 /**
@@ -95,6 +104,32 @@ export function addRef(graph: VineGraph, ref: RefTask): VineGraph {
 }
 
 /**
+ * Add a connective node (`anyof`/`allof`) to the graph.
+ *
+ * The connective is appended **after** all existing nodes in order so that the
+ * root remains first. A connective must declare at least one dependency
+ * (enforced by validation).
+ *
+ * @throws {VineError} if a node with the same id already exists.
+ * @throws {VineValidationError} if the resulting graph is invalid.
+ */
+export function addConnective(
+  graph: VineGraph,
+  connective: ConnectiveNode,
+): VineGraph {
+  if (graph.tasks.has(connective.id)) {
+    throw new VineError(`Task "${connective.id}" already exists.`);
+  }
+
+  const newTasks = replaceTask(graph.tasks, connective);
+  const newOrder = [...graph.order, connective.id];
+
+  const next = buildGraph(newTasks, newOrder, graph);
+  validate(next);
+  return next;
+}
+
+/**
  * Remove a task from the graph.
  *
  * Also strips the removed id from every other task's `dependencies` array.
@@ -147,8 +182,10 @@ export function setStatus(
   if (!task) {
     throw new VineError(`Task not found: ${id}`);
   }
-  if (task.kind === 'ref') {
-    throw new VineError(`Cannot set status on reference node "${id}".`);
+  if (task.kind !== 'task') {
+    throw new VineError(
+      `Cannot set status on ${nodeKindLabel(task.kind)} node "${id}".`,
+    );
   }
 
   const updated: ConcreteTask = { ...task, status };
@@ -179,8 +216,10 @@ export function updateTask(
   if (!task) {
     throw new VineError(`Task not found: ${id}`);
   }
-  if (task.kind === 'ref' && fields.attachments !== undefined) {
-    throw new VineError(`Cannot set attachments on reference node "${id}".`);
+  if (task.kind !== 'task' && fields.attachments !== undefined) {
+    throw new VineError(
+      `Cannot set attachments on ${nodeKindLabel(task.kind)} node "${id}".`,
+    );
   }
 
   const updated: Task = { ...task, ...fields } as Task;
@@ -361,6 +400,24 @@ export function applyBatch(
         break;
       }
 
+      case 'add_connective': {
+        if (tasks.has(op.id)) {
+          throw new VineError(`Task "${op.id}" already exists.`);
+        }
+        const newConnective: ConnectiveNode = {
+          kind: op.kind,
+          id: op.id,
+          shortName: op.name,
+          description: op.description ?? '',
+          dependencies: op.dependsOn ?? [],
+          decisions: op.decisions ?? [],
+          annotations: EMPTY_ANNOTATIONS,
+        };
+        tasks.set(op.id, newConnective);
+        order.push(op.id);
+        break;
+      }
+
       case 'remove_task': {
         if (!tasks.has(op.id)) {
           throw new VineError(`Task not found: ${op.id}`);
@@ -386,9 +443,9 @@ export function applyBatch(
         if (!task) {
           throw new VineError(`Task not found: ${op.id}`);
         }
-        if (task.kind === 'ref') {
+        if (task.kind !== 'task') {
           throw new VineError(
-            `Cannot set status on reference node "${op.id}".`,
+            `Cannot set status on ${nodeKindLabel(task.kind)} node "${op.id}".`,
           );
         }
         tasks.set(op.id, { ...task, status: op.status });
@@ -400,8 +457,10 @@ export function applyBatch(
         if (!task) {
           throw new VineError(`Task not found: ${op.id}`);
         }
-        if (task.kind === 'ref') {
-          throw new VineError(`Cannot claim reference node "${op.id}".`);
+        if (task.kind !== 'task') {
+          throw new VineError(
+            `Cannot claim ${nodeKindLabel(task.kind)} node "${op.id}".`,
+          );
         }
         tasks.set(op.id, { ...task, status: 'started' as Status });
         break;
@@ -417,8 +476,8 @@ export function applyBatch(
         if (op.description !== undefined) patch.description = op.description;
         if (op.decisions !== undefined) patch.decisions = op.decisions;
         if (op.attachments !== undefined) {
-          if (task.kind === 'ref') {
-            throw new VineError(`Cannot set attachments on reference node "${op.id}".`);
+          if (task.kind !== 'task') {
+            throw new VineError(`Cannot set attachments on ${nodeKindLabel(task.kind)} node "${op.id}".`);
           }
           patch.attachments = op.attachments;
         }

--- a/packages/core/src/parser/blocks.ts
+++ b/packages/core/src/parser/blocks.ts
@@ -7,6 +7,8 @@ import type {
   Attachment,
   AttachmentClass,
   ConcreteTask,
+  ConnectiveKind,
+  ConnectiveNode,
   RefTask,
   Status,
   Task,
@@ -16,6 +18,7 @@ import {
   ATTACHMENT_CLASSES,
   HEADER_RE,
   REF_HEADER_RE,
+  CONNECTIVE_HEADER_RE,
   ANNOTATION_RE,
 } from './constants.js';
 import { VineParseError } from '../errors.js';
@@ -116,7 +119,7 @@ function findHeaderIndex(block: RawBlock): number {
 }
 
 /** Discriminated result of parsing a block header line. */
-type ParsedHeader = ParsedTaskHeader | ParsedRefHeader;
+type ParsedHeader = ParsedTaskHeader | ParsedRefHeader | ParsedConnectiveHeader;
 
 interface ParsedTaskHeader {
   readonly kind: 'task';
@@ -132,6 +135,14 @@ interface ParsedRefHeader {
   readonly id: string;
   readonly shortName: string;
   readonly vine: string;
+  readonly headerIndex: number;
+  readonly annotations: ReadonlyMap<string, readonly string[]>;
+}
+
+interface ParsedConnectiveHeader {
+  readonly kind: ConnectiveKind;
+  readonly id: string;
+  readonly shortName: string;
   readonly headerIndex: number;
   readonly annotations: ReadonlyMap<string, readonly string[]>;
 }
@@ -198,6 +209,28 @@ function parseHeader(block: RawBlock): ParsedHeader {
     }
     const annotations = parseAnnotations(match[4] ?? '');
     return { kind: 'ref', id, shortName, vine, headerIndex, annotations };
+  }
+
+  // Connective headers (`anyof `/`allof `). Dispatch on the first token.
+  if (headerLine.startsWith('anyof ') || headerLine.startsWith('allof ')) {
+    const match = CONNECTIVE_HEADER_RE.exec(headerLine);
+    if (!match) {
+      throw new VineParseError(
+        `Invalid connective header: "${headerLine}"`,
+        lineNumber,
+      );
+    }
+    const kind = match[1] as ConnectiveKind | undefined;
+    const id = match[2];
+    const shortName = match[3];
+    if (kind === undefined || id === undefined || shortName === undefined) {
+      throw new VineParseError(
+        `Invalid connective header: "${headerLine}"`,
+        lineNumber,
+      );
+    }
+    const annotations = parseAnnotations(match[4] ?? '');
+    return { kind, id, shortName, headerIndex, annotations };
   }
 
   // Otherwise, try concrete task header.
@@ -273,9 +306,11 @@ export function parseBlock(block: RawBlock): Task {
       for (const cls of ATTACHMENT_CLASSES) {
         const prefix = `@${cls} `;
         if (line.startsWith(prefix)) {
-          if (header.kind === 'ref') {
+          if (header.kind !== 'task') {
+            const nodeKind =
+              header.kind === 'ref' ? 'reference' : 'connective';
             throw new VineParseError(
-              'Attachments are not allowed on reference nodes',
+              `Attachments are not allowed on ${nodeKind} nodes`,
               lineNumber,
             );
           }
@@ -313,16 +348,30 @@ export function parseBlock(block: RawBlock): Task {
     return ref;
   }
 
-  const task: ConcreteTask = {
-    kind: 'task',
+  if (header.kind === 'task') {
+    const task: ConcreteTask = {
+      kind: 'task',
+      id: header.id,
+      shortName: header.shortName,
+      description,
+      status: header.status,
+      dependencies,
+      decisions,
+      attachments,
+      annotations: header.annotations,
+    };
+    return task;
+  }
+
+  // Connective node (anyof / allof).
+  const connective: ConnectiveNode = {
+    kind: header.kind,
     id: header.id,
     shortName: header.shortName,
     description,
-    status: header.status,
     dependencies,
     decisions,
-    attachments,
     annotations: header.annotations,
   };
-  return task;
+  return connective;
 }

--- a/packages/core/src/parser/constants.ts
+++ b/packages/core/src/parser/constants.ts
@@ -18,6 +18,17 @@ export const HEADER_RE =
 export const REF_HEADER_RE =
   /^ref\s+\[([a-zA-Z0-9-]+(?:\/[a-zA-Z0-9-]+)*)\]\s+(.+?)\s+\((\S+)\)((?:\s+@[a-zA-Z][a-zA-Z0-9]*\([^)]*\))*)$/;
 
+/**
+ * Matches a connective node header: `anyof [id] Short Name` / `allof [id] Short Name`.
+ *
+ * Unlike task and ref headers, a connective header has **no** trailing
+ * parenthesized field (no status, no URI) — the short name runs to the end of
+ * the line, minus any header annotations. The leading keyword is captured so a
+ * single regex serves both modes.
+ */
+export const CONNECTIVE_HEADER_RE =
+  /^(anyof|allof)\s+\[([a-zA-Z0-9-]+(?:\/[a-zA-Z0-9-]+)*)\]\s+(.+?)((?:\s+@[a-zA-Z][a-zA-Z0-9]*\([^)]*\))*)$/;
+
 /** Matches a single annotation: @key(values) */
 export const ANNOTATION_RE = /@([a-zA-Z][a-zA-Z0-9]*)\(([^)]*)\)/g;
 

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -135,7 +135,12 @@ export function getSummary(graph: VineGraph): GraphSummary {
     reviewing: 0,
   };
 
+  // Connectives are routing infrastructure, not deliverable work — they are
+  // excluded from `total`, consistent with `ExecutionProgress.total`.
+  let total = 0;
   for (const task of graph.tasks.values()) {
+    if (isConnective(task)) continue;
+    total += 1;
     if (task.kind === 'task') {
       byStatus[task.status] += 1;
     }
@@ -148,7 +153,7 @@ export function getSummary(graph: VineGraph): GraphSummary {
   const root = getTask(graph, rootId);
 
   return {
-    total: graph.tasks.size,
+    total,
     byStatus,
     rootId: root.id,
     rootName: root.shortName,

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -5,8 +5,8 @@ import type {
   Task,
   VineGraph,
 } from './types.js';
-import { isVineRef, isConcreteTask } from './types.js';
-import { getTask, getDependencies, getDependants } from './graph.js';
+import { isVineRef, isConcreteTask, isConnective } from './types.js';
+import { getTask, getDependants } from './graph.js';
 import { VineError } from './errors.js';
 
 /**
@@ -220,6 +220,94 @@ const CONSUMING_STATUSES: ReadonlySet<Status> = new Set<Status>([
 ]);
 
 /**
+ * Build a memoized satisfaction predicate for a graph.
+ *
+ * A node is *satisfied* when it can count as a completed prerequisite for its
+ * dependants:
+ *
+ * - concrete task → status is `complete` or `reviewing` (the base rule).
+ * - ref           → never (an unexpanded ref must be expanded first).
+ * - `anyof`       → **any** direct dependency is satisfied.
+ * - `allof`       → **every** direct dependency is satisfied.
+ *
+ * Connectives resolve recursively; termination is guaranteed by the DAG
+ * constraint. Results are memoized per call so each node is evaluated once.
+ */
+export function buildSatisfaction(graph: VineGraph): (id: string) => boolean {
+  const memo = new Map<string, boolean>();
+  const inProgress = new Set<string>();
+
+  function satisfied(id: string): boolean {
+    const cached = memo.get(id);
+    if (cached !== undefined) return cached;
+    // Defensive cycle guard — a validated graph is acyclic, but never recurse
+    // forever if an unvalidated graph slips through.
+    if (inProgress.has(id)) return false;
+
+    const task = graph.tasks.get(id);
+    if (!task) return false;
+
+    inProgress.add(id);
+    let result: boolean;
+    switch (task.kind) {
+      case 'task':
+        result = SATISFIED_STATUSES.has(task.status);
+        break;
+      case 'ref':
+        result = false;
+        break;
+      case 'anyof':
+        result = task.dependencies.some((d) => satisfied(d));
+        break;
+      case 'allof':
+        result = task.dependencies.every((d) => satisfied(d));
+        break;
+    }
+    inProgress.delete(id);
+    memo.set(id, result);
+    return result;
+  }
+
+  return satisfied;
+}
+
+/**
+ * Returns true when some concrete task has started consuming `id`'s output,
+ * looking **through** connective nodes transparently.
+ *
+ * A `reviewing` task is safe to complete once a downstream consumer has picked
+ * up its output. With a connective interposed between the reviewing task and
+ * its real consumers, the connective is transparent: we forward reverse-edge
+ * traversal through connective dependants but stop at concrete/ref dependants.
+ */
+function hasConsumingDependant(graph: VineGraph, id: string): boolean {
+  const visited = new Set<string>([id]);
+  const queue: string[] = getDependants(graph, id).map((d) => d.id);
+
+  while (queue.length > 0) {
+    const depId = queue.shift();
+    if (depId === undefined) break;
+    if (visited.has(depId)) continue;
+    visited.add(depId);
+
+    const dep = graph.tasks.get(depId);
+    if (!dep) continue;
+
+    if (isConcreteTask(dep)) {
+      if (CONSUMING_STATUSES.has(dep.status)) return true;
+      // A non-consuming concrete task does not forward consumption.
+      continue;
+    }
+    if (isConnective(dep)) {
+      // Transparent: look through to the connective's own dependants.
+      for (const d of getDependants(graph, depId)) queue.push(d.id);
+    }
+    // Ref dependants are not consumers and are not traversed.
+  }
+  return false;
+}
+
+/**
  * Analyse the current state of a VineGraph and return the execution frontier:
  * tasks that are ready to start, reviewing tasks that can be completed, and
  * ref nodes that need expansion.
@@ -235,7 +323,12 @@ export function getActionableTasks(graph: VineGraph): ActionableTasks {
   const blocked: ConcreteTask[] = [];
   const expandable: RefTask[] = [];
 
+  const satisfied = buildSatisfaction(graph);
+
   let completeCount = 0;
+  // Connective nodes are routing infrastructure, not deliverable work — they
+  // are excluded from the progress denominator.
+  let workTotal = 0;
   const byStatus: Record<Status, number> = {
     complete: 0,
     notstarted: 0,
@@ -248,19 +341,23 @@ export function getActionableTasks(graph: VineGraph): ActionableTasks {
   for (const id of graph.order) {
     const task = getTask(graph, id);
 
+    // Connectives are pure routing — never counted as work, never in the
+    // frontier. Their effect is felt only through the satisfaction predicate.
+    if (isConnective(task)) continue;
+
+    workTotal += 1;
+
     // Count statuses for progress (only concrete tasks have a status).
     if (isConcreteTask(task)) {
       byStatus[task.status] += 1;
       if (task.status === 'complete') completeCount += 1;
     }
 
-    // Check whether all dependencies are satisfied.
-    const deps = getDependencies(graph, id);
-    const allDepsSatisfied = deps.every((dep) => {
-      if (isConcreteTask(dep)) return SATISFIED_STATUSES.has(dep.status);
-      // Ref nodes are never "satisfied" — they must be expanded first.
-      return false;
-    });
+    // Check whether all dependencies are satisfied (connectives resolve
+    // recursively inside `satisfied`).
+    const allDepsSatisfied = task.dependencies.every((depId) =>
+      satisfied(depId),
+    );
 
     if (!allDepsSatisfied) continue;
 
@@ -282,14 +379,10 @@ export function getActionableTasks(graph: VineGraph): ActionableTasks {
       continue;
     }
 
-    // Reviewing tasks: completable when at least one dependant is consuming.
+    // Reviewing tasks: completable when a consumer (seen through connectives)
+    // has started consuming the output.
     if (task.status === 'reviewing') {
-      const dependants = getDependants(graph, id);
-      const anyConsuming = dependants.some((d) => {
-        if (isConcreteTask(d)) return CONSUMING_STATUSES.has(d.status);
-        return false;
-      });
-      if (anyConsuming) {
+      if (hasConsumingDependant(graph, id)) {
         completable.push(task);
       }
     }
@@ -313,6 +406,8 @@ export function getActionableTasks(graph: VineGraph): ActionableTasks {
   ) {
     const allOthersFinished = [...graph.tasks.values()].every((t) => {
       if (t.id === root.id) return true;
+      // Connectives are routing infrastructure, not work — ignore them here.
+      if (isConnective(t)) return true;
       if (isConcreteTask(t)) return SATISFIED_STATUSES.has(t.status);
       // Unexpanded ref nodes block root completion.
       return false;
@@ -322,7 +417,7 @@ export function getActionableTasks(graph: VineGraph): ActionableTasks {
     }
   }
 
-  const total = graph.tasks.size;
+  const total = workTotal;
   const percentage = total > 0 ? Math.round((completeCount / total) * 100) : 0;
 
   return {

--- a/packages/core/src/serializer.ts
+++ b/packages/core/src/serializer.ts
@@ -83,7 +83,7 @@ export function serialize(graph: VineGraph): string {
       for (const decision of task.decisions) {
         lines.push(`> ${decision}`);
       }
-    } else {
+    } else if (task.kind === 'task') {
       // ── Concrete task node ──────────────────────────────────────
       // Header — status is guaranteed defined for concrete tasks
       lines.push(
@@ -112,6 +112,29 @@ export function serialize(graph: VineGraph): string {
         for (const att of task.attachments.filter((a) => a.class === cls)) {
           lines.push(`@${att.class} ${att.mime} ${att.uri}`);
         }
+      }
+    } else {
+      // ── Connective node (anyof / allof) ─────────────────────────
+      // No status, no URI, no attachments — just an id + short name.
+      lines.push(
+        `${task.kind} [${task.id}] ${task.shortName}${serializeAnnotations(task.annotations)}`,
+      );
+
+      // Description
+      if (task.description !== '') {
+        for (const descLine of task.description.split('\n')) {
+          lines.push(descLine);
+        }
+      }
+
+      // Dependencies — sorted alphabetically
+      for (const dep of [...task.dependencies].sort()) {
+        lines.push(`-> ${dep}`);
+      }
+
+      // Decisions — original order
+      for (const decision of task.decisions) {
+        lines.push(`> ${decision}`);
       }
     }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -58,10 +58,29 @@ export interface RefTask extends BaseNode {
 }
 
 /**
- * A single node in the vine graph — either a concrete task or a reference.
- * Discriminate on `kind` (`'task'` or `'ref'`) for full type narrowing.
+ * The two connective modes.
+ *
+ * - `anyof` — satisfied when **any** direct dependency is satisfied (∨).
+ * - `allof` — satisfied when **every** direct dependency is satisfied (∧).
  */
-export type Task = ConcreteTask | RefTask;
+export type ConnectiveKind = 'anyof' | 'allof';
+
+/**
+ * A first-class connective (routing) node. It names a derived readiness
+ * condition over its direct dependencies. Connective nodes carry no writable
+ * status and no attachments; they cannot be claimed or completed and never
+ * enter the execution frontier. A dependant treats a satisfied connective as a
+ * satisfied prerequisite. `ref` is the structural-node precedent this extends.
+ */
+export interface ConnectiveNode extends BaseNode {
+  readonly kind: ConnectiveKind;
+}
+
+/**
+ * A single node in the vine graph — a concrete task, a reference, or a
+ * connective (`anyof`/`allof`). Discriminate on `kind` for full type narrowing.
+ */
+export type Task = ConcreteTask | RefTask | ConnectiveNode;
 
 /**
  * An immutable task graph parsed from a .vine file.
@@ -122,6 +141,13 @@ export function isConcreteTask(task: Task): task is ConcreteTask {
 }
 
 /**
+ * Type guard: returns true when `task` is a connective node (`anyof`/`allof`).
+ */
+export function isConnective(task: Task): task is ConnectiveNode {
+  return task.kind === 'anyof' || task.kind === 'allof';
+}
+
+/**
  * Returns the first `@sprite` annotation URI from a task, or `undefined`
  * if the task has no sprite annotation.
  */
@@ -149,5 +175,6 @@ export type Operation =
   | { op: 'add_dep'; taskId: string; depId: string }
   | { op: 'remove_dep'; taskId: string; depId: string }
   | { op: 'add_ref'; id: string; name: string; vine: string; description?: string; dependsOn?: string[]; decisions?: string[] }
+  | { op: 'add_connective'; id: string; name: string; kind: ConnectiveKind; description?: string; dependsOn?: string[]; decisions?: string[] }
   | { op: 'update_ref_uri'; id: string; uri: string }
   | { op: 'extract_to_ref'; id: string; vine: string; refName?: string };

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -184,6 +184,44 @@ function checkRefUriRequired(graph: VineGraph): void {
 // Constraint 6 (no-ref-attachments) is now enforced at the type level:
 // RefTask has no `attachments` field, so no runtime check is needed.
 
+/**
+ * 6. Connective nodes (`anyof`/`allof`) must declare at least one dependency.
+ *
+ * A zero-dependency `anyof` can never be satisfied (a silent permanent block);
+ * a zero-dependency `allof` is vacuously satisfied (a silent no-op). Both are
+ * almost certainly authoring errors, so they are rejected rather than guessed.
+ */
+function checkConnectiveHasDeps(graph: VineGraph): void {
+  for (const [taskId, task] of graph.tasks) {
+    if (task.kind === 'anyof' || task.kind === 'allof') {
+      if (task.dependencies.length === 0) {
+        fail(
+          `Connective node "${taskId}" (${task.kind}) must declare at least one dependency.`,
+          { constraint: 'connective-has-deps', taskId },
+        );
+      }
+    }
+  }
+}
+
+/**
+ * 7. The root (first block) must not be a connective node.
+ *
+ * The root represents the graph's goal and carries a status; a connective has
+ * neither a status nor a lifecycle, so it may not occupy the root slot.
+ */
+function checkRootNotConnective(graph: VineGraph): void {
+  const rootId = graph.order[0];
+  if (rootId === undefined) return; // unreachable after constraint 1.
+  const root = graph.tasks.get(rootId);
+  if (root && (root.kind === 'anyof' || root.kind === 'allof')) {
+    fail(`Root node "${rootId}" must not be a connective (${root.kind}).`, {
+      constraint: 'root-not-connective',
+      taskId: rootId,
+    });
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -200,6 +238,8 @@ function checkRefUriRequired(graph: VineGraph): void {
  *  3. no-cycles
  *  4. no-islands
  *  5. ref-uri-required
+ *  6. connective-has-deps
+ *  7. root-not-connective
  */
 export function validate(graph: VineGraph): void {
   checkAtLeastOneTask(graph);
@@ -207,4 +247,6 @@ export function validate(graph: VineGraph): void {
   checkNoCycles(graph);
   checkNoIslands(graph);
   checkRefUriRequired(graph);
+  checkConnectiveHasDeps(graph);
+  checkRootNotConnective(graph);
 }

--- a/packages/mcp/__tests__/handlers.test.ts
+++ b/packages/mcp/__tests__/handlers.test.ts
@@ -274,6 +274,51 @@ describe('vine_write handler', () => {
     expect(data.progress.total).toBe(2);
   });
 
+  it('add_connective creates an anyof routing node callable via MCP', async () => {
+    const dir = makeTempDir();
+    const file = join(dir, 'connective.vine');
+    const result = await callTool(tc.client, 'vine_write', {
+      file,
+      operations: [
+        { op: 'create', version: '1.3.0' },
+        { op: 'add_task', id: 'root', name: 'Root' },
+        { op: 'add_task', id: 'a', name: 'A', status: 'complete' },
+        { op: 'add_task', id: 'b', name: 'B', status: 'notstarted' },
+        { op: 'add_connective', id: 'gate', name: 'Any input', kind: 'anyof', dependsOn: ['a', 'b'] },
+        { op: 'add_dep', taskId: 'root', depId: 'gate' },
+      ],
+    });
+    expect(result.isError).toBeUndefined();
+    const data = resultJSON(result) as { summary: string; progress: { total: number } };
+    expect(data.summary).toContain('added anyof "gate"');
+    // Connectives are routing infrastructure — excluded from the work total.
+    expect(data.progress.total).toBe(3);
+
+    // Read it back: the node persisted as a connective, no status.
+    const read = await callTool(tc.client, 'vine_read', { file, action: 'task', id: 'gate' });
+    const task = resultJSON(read) as { kind: string; dependencies: string[]; status?: string };
+    expect(task.kind).toBe('anyof');
+    expect([...task.dependencies].sort()).toEqual(['a', 'b']);
+    expect(task.status).toBeUndefined();
+  });
+
+  it('add_connective rejects an invalid kind', async () => {
+    const dir = makeTempDir();
+    const file = join(dir, 'bad-connective.vine');
+    const result = await callTool(tc.client, 'vine_write', {
+      file,
+      operations: [
+        { op: 'create', version: '1.3.0' },
+        { op: 'add_task', id: 'root', name: 'Root' },
+        { op: 'add_task', id: 'a', name: 'A', status: 'complete' },
+        { op: 'add_connective', id: 'gate', name: 'Bad', kind: 'someof', dependsOn: ['a'] },
+        { op: 'add_dep', taskId: 'root', depId: 'gate' },
+      ],
+    });
+    expect(result.isError).toBe(true);
+    expect(resultText(result)).toContain('anyof');
+  });
+
   it('create without add_task fails', async () => {
     const dir = makeTempDir();
     const file = join(dir, 'fail-create.vine');

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -63,7 +63,11 @@ function formatTask(task: Task): Record<string, unknown> {
       })),
     };
   }
-  return { ...base, vine: task.vine };
+  if (task.kind === 'ref') {
+    return { ...base, vine: task.vine };
+  }
+  // Connective node (anyof/allof): no status, no vine, no attachments.
+  return base;
 }
 
 function formatError(error: unknown, file: string): string {
@@ -237,7 +241,7 @@ export function createServer(): McpServer {
                 id: d.id,
                 shortName: d.shortName,
                 kind: d.kind,
-                ...(d.kind === 'task' ? { status: d.status, decisions: [...d.decisions], attachments: d.attachments.map((a) => ({ class: a.class, mime: a.mime, uri: a.uri })) } : { vine: d.vine, decisions: [...d.decisions] }),
+                ...(d.kind === 'task' ? { status: d.status, decisions: [...d.decisions], attachments: d.attachments.map((a) => ({ class: a.class, mime: a.mime, uri: a.uri })) } : d.kind === 'ref' ? { vine: d.vine, decisions: [...d.decisions] } : { decisions: [...d.decisions] }),
               })),
               dependant_tasks: dependants.map((d) => ({
                 id: d.id,
@@ -338,6 +342,7 @@ export function createServer(): McpServer {
         '• add_dep — { op, taskId, depId }\n' +
         '• remove_dep — { op, taskId, depId }\n' +
         '• add_ref — { op, id, name, vine, description?, dependsOn?: string[], decisions?: string[] }\n' +
+        '• add_connective — { op, id, name, kind: "anyof"|"allof", description?, dependsOn?: string[], decisions?: string[] } A routing node satisfied when ANY (anyof) or ALL (allof) of its dependsOn are satisfied. Carries no status, cannot be claimed/completed, and never appears in the frontier — a dependant treats a satisfied connective as a met prerequisite. Use anyof for "wait-any" / disjunctive triggers. Must have ≥1 dependsOn.\n' +
         '• extract_to_ref — { op, id, vine, refName? } Extract a task into a new child .vine file and replace it with a ref node. Preserves dependency edges.\n' +
         '• update_ref_uri — { op, id, uri }\n\n' +
         'Batch semantics: validation runs only after all operations. Returns structured JSON with operation summary, progress snapshot, and execution frontier (ready_to_start, ready_to_complete, blocked, needs_expansion).',
@@ -476,6 +481,21 @@ export function createServer(): McpServer {
               if (Array.isArray(o.decisions)) ref.decisions = assertStringArray(o.decisions as unknown[], 'add_ref "decisions"', i);
               return ref;
             }
+            case 'add_connective': {
+              if (typeof o.id !== 'string') throw new VineError(`Operation ${String(i)}: add_connective requires "id".`);
+              if (typeof o.name !== 'string') throw new VineError(`Operation ${String(i)}: add_connective requires "name".`);
+              if (o.kind !== 'anyof' && o.kind !== 'allof') throw new VineError(`Operation ${String(i)}: add_connective requires "kind" to be "anyof" or "allof".`);
+              const conn: { op: 'add_connective'; id: string; name: string; kind: 'anyof' | 'allof'; description?: string; dependsOn?: string[]; decisions?: string[] } = {
+                op: 'add_connective',
+                id: o.id,
+                name: o.name,
+                kind: o.kind,
+              };
+              if (typeof o.description === 'string') conn.description = o.description;
+              if (Array.isArray(o.dependsOn)) conn.dependsOn = assertStringArray(o.dependsOn as unknown[], 'add_connective "dependsOn"', i);
+              if (Array.isArray(o.decisions)) conn.decisions = assertStringArray(o.decisions as unknown[], 'add_connective "decisions"', i);
+              return conn;
+            }
             case 'update_ref_uri': {
               if (typeof o.id !== 'string') throw new VineError(`Operation ${String(i)}: update_ref_uri requires "id".`);
               if (typeof o.uri !== 'string') throw new VineError(`Operation ${String(i)}: update_ref_uri requires "uri".`);
@@ -547,7 +567,8 @@ export function createServer(): McpServer {
               case 'update': return `updated "${o.id}"`;
               case 'add_dep': return `added dep ${o.taskId} → ${o.depId}`;
               case 'remove_dep': return `removed dep ${o.taskId} → ${o.depId}`;
-              case 'add_ref': return `added ref "${o.id}"`;
+              case 'add_ref': return `added ref ""`;
+              case 'add_connective': return `added ${o.kind} "${o.id}"`;
               case 'update_ref_uri': return `updated ref URI for "${o.id}"`;
               case 'create': return 'created graph';
               case 'extract_to_ref': return `extracted "${o.id}" to ref (${o.vine})`;
@@ -592,6 +613,9 @@ export function createServer(): McpServer {
           }
           if (task.kind === 'ref') {
             throw new VineError(`Task "${extractOp.id}" is already a reference node.`);
+          }
+          if (task.kind !== 'task') {
+            throw new VineError(`Cannot extract a ${task.kind} node to a ref.`);
           }
 
           // Build child graph with the extracted task as root
@@ -648,7 +672,8 @@ export function createServer(): McpServer {
               case 'update': return `updated "${o.id}"`;
               case 'add_dep': return `added dep ${o.taskId} → ${o.depId}`;
               case 'remove_dep': return `removed dep ${o.taskId} → ${o.depId}`;
-              case 'add_ref': return `added ref "${o.id}"`;
+              case 'add_ref': return `added ref ""`;
+              case 'add_connective': return `added ${o.kind} "${o.id}"`;
               case 'update_ref_uri': return `updated ref URI for "${o.id}"`;
               case 'create': return 'created graph';
             }
@@ -686,7 +711,8 @@ export function createServer(): McpServer {
             case 'update': return `updated "${o.id}"`;
             case 'add_dep': return `added dep ${o.taskId} → ${o.depId}`;
             case 'remove_dep': return `removed dep ${o.taskId} → ${o.depId}`;
-            case 'add_ref': return `added ref "${o.id}"`;
+            case 'add_ref': return `added ref ""`;
+            case 'add_connective': return `added ${o.kind} "${o.id}"`;
             case 'update_ref_uri': return `updated ref URI for "${o.id}"`;
             case 'create': return 'created graph';
             case 'extract_to_ref': return `extracted "${o.id}" to ref (${o.vine})`;
@@ -708,7 +734,7 @@ export function createServer(): McpServer {
                 id: d.id,
                 shortName: d.shortName,
                 kind: d.kind,
-                ...(d.kind === 'task' ? { status: d.status, decisions: [...d.decisions], attachments: d.attachments.map((a) => ({ class: a.class, mime: a.mime, uri: a.uri })) } : { vine: d.vine, decisions: [...d.decisions] }),
+                ...(d.kind === 'task' ? { status: d.status, decisions: [...d.decisions], attachments: d.attachments.map((a) => ({ class: a.class, mime: a.mime, uri: a.uri })) } : d.kind === 'ref' ? { vine: d.vine, decisions: [...d.decisions] } : { decisions: [...d.decisions] }),
               })),
             });
           }

--- a/packages/ui/__tests__/chat/integration.test.ts
+++ b/packages/ui/__tests__/chat/integration.test.ts
@@ -20,6 +20,13 @@ import type { ChatLogger } from '../../src/lib/chat/types.js';
 
 const API_KEY = process.env.ANTHROPIC_API_KEY ?? '';
 
+/**
+ * Model used for live integration tests. Overridable via env so CI can bump
+ * the model without a code change. The default must be a currently served
+ * model ID — retired IDs 404 with `not_found_error`, failing both tests.
+ */
+const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL ?? 'claude-sonnet-5';
+
 /** Structured logger that writes to stderr so vitest captures it. */
 const testLogger: ChatLogger = {
   log(level, message, data) {
@@ -73,7 +80,7 @@ Compile the source code.
     async () => {
       const service = new AnthropicChatService({
         apiKey: API_KEY,
-        model: 'claude-sonnet-4-20250514',
+        model: ANTHROPIC_MODEL,
         logger: testLogger,
       });
 

--- a/packages/ui/__tests__/chat/integration.test.ts
+++ b/packages/ui/__tests__/chat/integration.test.ts
@@ -128,7 +128,7 @@ Compile the source code.
   it('streams text content from the model', { timeout: 60_000 }, async () => {
     const service = new AnthropicChatService({
       apiKey: API_KEY,
-      model: 'claude-sonnet-4-20250514',
+      model: ANTHROPIC_MODEL,
       logger: testLogger,
     });
 


### PR DESCRIPTION
## Summary

Adds **first-class connective (routing) nodes** to the VINE format — `anyof` and `allof` — resolving **#22** (distinguish `blocked`/needs-intervention from deferred/"wait-any").

```
[gap-memory] Belief beyond the window (notstarted)
-> memory-trigger
---
anyof [memory-trigger] First relevant regime signal
-> r4-scoping
-> spirit-2-intake
```

A connective is **satisfied** when **ANY** (`anyof`) or **ALL** (`allof`) of its direct dependencies are satisfied; a dependant treats a satisfied connective as a met prerequisite. Connectives carry no status, cannot be claimed or completed, and **never enter the execution frontier** — so `gap-memory` stays out of `ready_to_start` until the first upstream lands, with **no polling judgment task** and without overloading `blocked`.

This directly answers the sharpened, reopened ask in #22 (mechanical disjunctive / wait-any dependencies deserve first-class semantics).

## Design decision

Built as a **node kind**, *not* the `@anyof(...)` header annotation floated in the #22 thread — keeping routing in graph structure and annotations non-routing (consistent with the direction in #13). Rationale and the full trade-off table are in the design doc: `docs/VINE/proposals/connective-nodes.md`. **This fork is worth a maintainer decision before merge.**

## Changes

**`@bacchus/core`**
- **types** — `ConnectiveNode`/`ConnectiveKind`, `isConnective`, extended `Task` + `Operation` unions
- **parser** — `anyof`/`allof` header grammar + block parsing (attachments forbidden, like `ref`)
- **serializer** — emits connective blocks; round-trips
- **validator** — two new hard constraints: `connective-has-deps` (≥1 dep) and `root-not-connective`
- **frontier** — recursive `buildSatisfaction` predicate; connectives excluded from every bucket and from `progress.total`; `reviewing → completable` sees *through* connectives transparently
- **expansion** — connectives remap on inline
- **mutations** — `add_connective` op + `addConnective`; `set_status`/`claim`/attachment guards reject connectives

**MCP** — `vine_write` coerces + documents `add_connective`; `formatTask` and `resolved_dependencies` handle the third node kind.

**Incidental** — fixes pre-existing task-XOR-ref assumptions in `cli`/`mcp` exposed by the new kind; uses positive `kind === 'task'` narrowing (TS does not reliably narrow a union-typed discriminant).

## Validation constraints (new)
- **`connective-has-deps`** — an `anyof`/`allof` with zero deps is rejected (a zero-dep `anyof` can never satisfy; a zero-dep `allof` is a silent no-op).
- **`root-not-connective`** — the root has a goal/status; a connective has neither.

## Versioning
Grammar change → **VINE 1.3.0**. A 1.3.0 parser still accepts 1.0–1.2 files; a 1.2.0 parser correctly *rejects* 1.3.0 connective headers (fails loud rather than silently misrouting).

## Testing
- **+18 tests** (`packages/core/__tests__/connectives.test.ts` covering parse/serialize/validate/frontier/roundtrip/mutations; end-to-end MCP `add_connective` in `handlers.test.ts`)
- Full suite: **959 pass** / 2 skipped (live-agent), **`yarn lint` clean**

## Not included (deliberate follow-ups)
- UI/Svelte renderer still shows connectives with the generic ref glyph (🔗)
- No formal `docs/VINE/v1.3.0.md` spec doc yet (proposal doc is the current spec of record)
- Package versions not bumped

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)